### PR TITLE
Add hyphen for es.exe options

### DIFF
--- a/src/preview.js
+++ b/src/preview.js
@@ -45,7 +45,7 @@ class Preview extends React.Component {
             var term2 =this.props.term;
             console.log(term2);
             var cmd = espath+"/es.exe ";// -n 10 -s *" + term2 + "* ";
-            execFile(cmd,['s','n','20',term2], this.handleResults);
+            execFile(cmd,['-s','-n','20',term2], this.handleResults);
         }
     }
 


### PR DESCRIPTION
I'm using Everything command line executable `ES-1.1.0.8.zip`, which is download from [here](https://www.voidtools.com/downloads/). When I search files from Cerebro with this plugin, I get a empty result. I found that you've forgot to add hyphen for `es.exe` options. The problem is fixed when adding these hyphens.